### PR TITLE
Bump actions-setup-node to 2.4.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,9 +8,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - uses: guardian/actions-setup-node@v2.4.0
+            - uses: guardian/actions-setup-node@v2.4.1
               with:
-                cache: 'yarn'
+                  cache: "yarn"
             - name: build
               run: |
                   yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v1
-            - uses: guardian/actions-setup-node@v2.4.0
+            - uses: guardian/actions-setup-node@v2.4.1
               with:
-                cache: 'yarn'
+                  cache: "yarn"
             - name: build
               run: |
                   yarn


### PR DESCRIPTION
## What does this change?

Bumps the version of the [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) to 2.4.1

## How to test

Check the version of node being used in the CI workflow